### PR TITLE
Include xcode workspace and ignore xcuserdata.

### DIFF
--- a/myLauncher/MyLauncher.xcodeproj/.gitignore
+++ b/myLauncher/MyLauncher.xcodeproj/.gitignore
@@ -1,0 +1,1 @@
+xcuserdata

--- a/myLauncher/MyLauncher.xcodeproj/project.xcworkspace/.gitignore
+++ b/myLauncher/MyLauncher.xcodeproj/project.xcworkspace/.gitignore
@@ -1,0 +1,1 @@
+xcuserdata

--- a/myLauncher/MyLauncher.xcodeproj/project.xcworkspace/contents.xcworkspacedata
+++ b/myLauncher/MyLauncher.xcodeproj/project.xcworkspace/contents.xcworkspacedata
@@ -1,0 +1,7 @@
+<?xml version="1.0" encoding="UTF-8"?>
+<Workspace
+   version = "1.0">
+   <FileRef
+      location = "self:MyLauncher.xcodeproj">
+   </FileRef>
+</Workspace>


### PR DESCRIPTION
xcuserdata is user-specific xcode state and schemes, so we want to ignore that.  However, xcode workspaces contain default schemes for the project and are handy to include.
